### PR TITLE
update firebase sdk to 5.6.0

### DIFF
--- a/Example/ImageStore.xcodeproj/project.pbxproj
+++ b/Example/ImageStore.xcodeproj/project.pbxproj
@@ -354,12 +354,12 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ImageStore_Example/Pods-ImageStore_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,31 +4,31 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Firebase/CoreOnly (5.0.1):
-    - FirebaseCore (= 5.0.1)
-  - Firebase/Storage (5.0.1):
+  - Firebase/CoreOnly (5.6.0):
+    - FirebaseCore (= 5.1.1)
+  - Firebase/Storage (5.6.0):
     - Firebase/CoreOnly
     - FirebaseStorage (= 3.0.0)
-  - FirebaseCore (5.0.1):
-    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseCore (5.1.1):
+    - GoogleUtilities/Logger (~> 5.2)
   - FirebaseStorage (3.0.0):
     - FirebaseCore (~> 5.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleToolboxForMac/Defines (2.1.4)
-  - GoogleToolboxForMac/NSData+zlib (2.1.4):
-    - GoogleToolboxForMac/Defines (= 2.1.4)
-  - GTMSessionFetcher/Core (1.1.15)
-  - ImageStore (0.4.0):
-    - Firebase/Storage (~> 5.0.0)
+  - GoogleUtilities/Environment (5.2.2)
+  - GoogleUtilities/Logger (5.2.2):
+    - GoogleUtilities/Environment
+  - GTMSessionFetcher/Core (1.2.0)
+  - ImageStore (0.4.2):
+    - Firebase/Storage (~> 5.0)
   - iOSSnapshotTestCase (3.0.0):
     - iOSSnapshotTestCase/SwiftSupport (= 3.0.0)
   - iOSSnapshotTestCase/Core (3.0.0)
   - iOSSnapshotTestCase/SwiftSupport (3.0.0):
     - iOSSnapshotTestCase/Core
-  - Nimble (7.1.1)
-  - Nimble-Snapshots (6.7.0):
-    - Nimble-Snapshots/Core (= 6.7.0)
-  - Nimble-Snapshots/Core (6.7.0):
+  - Nimble (7.1.3)
+  - Nimble-Snapshots (6.7.1):
+    - Nimble-Snapshots/Core (= 6.7.1)
+  - Nimble-Snapshots/Core (6.7.1):
     - iOSSnapshotTestCase (~> 3.0)
     - Nimble (~> 7.0)
   - Quick (1.0.0)
@@ -46,15 +46,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Firebase: d6861c2059d8c32d1e6dd8932e22ada346d90a3a
-  FirebaseCore: cafc814b2d84fc8733f09e653041cc2165332ad7
+  Firebase: 75ea9e232eefa158c1049028030b8f661a2ccb62
+  FirebaseCore: cb9ee75e0894def766167c95a4d5a14b1c138269
   FirebaseStorage: 7ca4bb7b58a25fa647b04f524033fc7cb7eb272b
-  GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
-  GTMSessionFetcher: 5fa5b80fd20e439ef5f545fb2cb3ca6c6714caa2
-  ImageStore: 82d4584ee623d3642b591db229da33f15a41e066
+  GoogleUtilities: 06b66f9567769a7958db20a92f0128b2843e49d5
+  GTMSessionFetcher: 0c4baf0a73acd0041bf9f71ea018deedab5ea84e
+  ImageStore: 61646cc7a455063ff148e73fbb7a0c36fde36317
   iOSSnapshotTestCase: 23984ffe05289728d646cbb6a7a10b4fb1c93440
-  Nimble: 391f07782af4b37914f9bd7b2ffbb952731b8202
-  Nimble-Snapshots: d609110ac4ca76ea9de12b20bc5f0efb2127dd61
+  Nimble: 2839b01d1b31f6a6a7777a221f0d91cf52e8e27b
+  Nimble-Snapshots: 7ab1d5fd4a794b983805c6f6b8091fb00d772754
   Quick: 8024e4a47e6cc03a9d5245ef0948264fc6d27cff
 
 PODFILE CHECKSUM: ada343efa260c7a3e16b4d5ee0e82e632014c30d

--- a/ImageStore.podspec
+++ b/ImageStore.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ImageStore'
-  s.version          = '0.4.1'
+  s.version          = '0.4.2'
   s.summary          = 'Image downloader with memory cache supporting.'
 
 # This description is used to generate tags and improve search results.
@@ -40,5 +40,5 @@ If you want more info, look https://github.com/miup/ImageStore.git
   # s.frameworks = 'UIKit', 'MapKit'
   s.requires_arc = true
   s.static_framework = true
-  s.dependency 'Firebase/Storage', '~>5.0.0'
+  s.dependency 'Firebase/Storage', '~>5.0'
 end


### PR DESCRIPTION
I just fixed dependency of Firebase iOS SDK.
ImageStore is now available Firebase iOS SDK above v5.0 truly.🙏
We can use v5.0.x and v5.x 🎉

Please put git-tag `0.4.2` and run `bundle exec pod trunk` after merging this PR.