### PR TITLE
Made `downloadTaskByURLString `'s I/O thread-safe.

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - GoogleUtilities/Logger (6.2.1):
     - GoogleUtilities/Environment
   - GTMSessionFetcher/Core (1.2.2)
-  - ImageStore (0.4.3):
+  - ImageStore (0.5.0):
     - Firebase/Storage (~> 6.0)
   - iOSSnapshotTestCase (6.1.0):
     - iOSSnapshotTestCase/SwiftSupport (= 6.1.0)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   FirebaseStorage: 926d41552072b9fee67aa645760f05f87b7ce604
   GoogleUtilities: c7a0b08bda3bf808be823ed151f0e28ac6866e71
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
-  ImageStore: d4e4a17287b2162f91cb43fbfa6d6ea53495efdf
+  ImageStore: 74aa70bb0923cd76313e633aa6386122ed784e13
   iOSSnapshotTestCase: 30d540b0c8feb9d7f8ff97acc25a3804b48ee264
   Nimble: 622629381bda1dd5678162f21f1368cec7cbba60
   Nimble-Snapshots: 2ec985281eef0eb9fc69a469deee851363a50d0e


### PR DESCRIPTION
I encounted too many `EXEC_BAD_ACCESS` when `ImageStore` removed download task from `downloadTaskByURLString` after image fetched.
So, I implemented get/set/remove logic with serial queue and use `queue.sync{}` so that ImageStore didn't cause `EXEC_BAD_ACCESS` anymore.